### PR TITLE
fix: added missing '&' to wysiwyg save_field func

### DIFF
--- a/taxonomy-meta.php
+++ b/taxonomy-meta.php
@@ -515,7 +515,7 @@ class RW_Taxonomy_Meta {
 			// call defined method to save meta value, if there's no methods, call common one
 			$save_func = 'save_field_' . $type;
 			if ( method_exists( $this, $save_func ) ) {
-				call_user_func( array( $this, 'save_field_' . $type ), $meta, $field, $old, $new );
+				call_user_func( array( $this, 'save_field_' . $type ), &$meta, $field, $old, $new );
 			} else {
 				$this->save_field( $meta, $field, $old, $new );
 			}


### PR DESCRIPTION
See issue raised on the forum:
http://wordpress.org/support/topic/plugin-broken-20?replies=3#post-4117407
