### PR TITLE
Fixed action, get_current_screen wasn't loading.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: rilwis
 Donate link: http://www.deluxeblogtips.com/donate
 Tags: custom-fields, custom-field, meta, taxonomy, term
 Requires at least: 3.3
-Tested up to: 3.5.2
+Tested up to: 4.6.1
 Stable tag: 1.2
 
 Taxonomy Meta plugin helps you easily add meta values to terms, mimic custom post fields

--- a/taxonomy-meta.php
+++ b/taxonomy-meta.php
@@ -36,7 +36,7 @@ class RW_Taxonomy_Meta {
 		add_action( 'admin_init', array( $this, 'add' ), 100 );
 		add_action( 'edit_term', array( $this, 'save' ), 10, 2 );
 		add_action( 'delete_term', array( $this, 'delete' ), 10, 2 );
-		add_action( 'load-edit-tags.php', array( $this, 'load_edit_page' ) );
+		add_action( 'load-term.php', array( $this, 'load_edit_page' ) );
 	}
 
 	/**


### PR DESCRIPTION
I noticed get_current_screen wasn't loading. As announced here http://make.wordpress.org/core/2016/03/07/changes-to-the-term-edit-page-in-wordpress-4-5/ now we should hook to load-term.php instead of load-edit-tags.php
